### PR TITLE
Opt out of object.save()

### DIFF
--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -11,8 +11,10 @@ def get_transition_viewset_method(transition_name):
         object = self.get_object()
         transition_method = getattr(object, transition_name)
 
-        transition_method(by=self.request.user)
-        object.save()
+        do_save = transition_method(by=self.request.user)
+
+        if do_save is not False:
+            object.save()
 
         serializer = self.get_serializer(object)
         return Response(serializer.data)


### PR DESCRIPTION
Check the return value of invocation of transition_method to allow opting out of object.save()
