### PR TITLE
Allow post-transition saving to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ if `Article` had 2 transitions, `delete` and `publish`, the following API calls 
 
 - `POST /api/article/1234/delete/`
 - `POST /api/article/1234/publish/`
+
+### Saving
+
+By default, the model instance will be saved after the transition has been successfully called. This can be disabled with the `save_after_transition` attribute
+
+```python
+class ArticleViewSet(
+    get_viewset_transition_action_mixin(Article),
+    viewsets.ModelViewSet
+):
+    queryset = Article.objects.all()
+    save_after_transition = False
+```

--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -13,7 +13,7 @@ def get_transition_viewset_method(transition_name):
 
         transition_method(by=self.request.user)
 
-        if self.save_post_transition:
+        if self.save_after_transition:
             object.save()
 
         serializer = self.get_serializer(object)
@@ -31,7 +31,7 @@ def get_viewset_transition_action_mixin(model):
     instance = model()
 
     class Mixin(object):
-        save_post_transition = True
+        save_after_transition = True
 
     transitions = instance.get_all_status_transitions()
     transition_names = set(x.name for x in transitions)

--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -12,7 +12,9 @@ def get_transition_viewset_method(transition_name):
         transition_method = getattr(object, transition_name)
 
         transition_method(by=self.request.user)
-        object.save()
+
+        if self.save_post_transition:
+            object.save()
 
         serializer = self.get_serializer(object)
         return Response(serializer.data)
@@ -29,7 +31,7 @@ def get_viewset_transition_action_mixin(model):
     instance = model()
 
     class Mixin(object):
-        pass
+        save_post_transition = True
 
     transitions = instance.get_all_status_transitions()
     transition_names = set(x.name for x in transitions)


### PR DESCRIPTION
To disable saving after a transition on a particular viewset you would do

``` python
class MyViewset(...):
     save_post_transition = False
```
