### PR TITLE
Fix method name to work with latest django-fsm API.

### DIFF
--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -33,7 +33,7 @@ def get_viewset_transition_action_mixin(model):
     class Mixin(object):
         save_after_transition = True
 
-    transitions = instance.get_all_status_transitions()
+    transitions = instance.get_all_state_transitions()
     transition_names = set(x.name for x in transitions)
     for transition_name in transition_names:
         setattr(


### PR DESCRIPTION
django-fsm provides a method called `get_all_state_transitions` to get a list of
all available transitions.
