### PR TITLE
Allow passing of arguments to the `@detail_route` decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ if `Article` had 2 transitions, `delete` and `publish`, the following API calls 
 - `POST /api/article/1234/delete/`
 - `POST /api/article/1234/publish/`
 
+### Custom route arguments
+
+Passing arguments to the `@detail_route` decorator can be done by specifiying
+them in the `get_viewset_transition_action_mixin` method:
+
+```python
+class ArticleViewSet(
+    get_viewset_transition_action_mixin(Article, permission_classes=[...]),
+    viewsets.ModelViewSet
+):
+    queryset = Article.objects.all()
+```
+
+This will set `permission_classes` on each `@detail_route` for all transitions.
+There is currrently no way to specify individual arguments for each transition.
+
 ### Saving
 
 By default, the model instance will be saved after the transition has been successfully called. This can be disabled with the `save_after_transition` attribute

--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -2,11 +2,11 @@ from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
 
-def get_transition_viewset_method(transition_name):
+def get_transition_viewset_method(transition_name, **kwargs):
     '''
     Create a viewset method for the provided `transition_name`
     '''
-    @detail_route(methods=['post'])
+    @detail_route(methods=['post'], **kwargs)
     def inner_func(self, request, pk=None):
         object = self.get_object()
         transition_method = getattr(object, transition_name)
@@ -22,7 +22,7 @@ def get_transition_viewset_method(transition_name):
     return inner_func
 
 
-def get_viewset_transition_action_mixin(model):
+def get_viewset_transition_action_mixin(model, **kwargs):
     '''
     Find all transitions defined on `model`, then create a corresponding
     viewset action method for each and apply it to `Mixin`. Finally, return
@@ -39,7 +39,7 @@ def get_viewset_transition_action_mixin(model):
         setattr(
             Mixin,
             transition_name,
-            get_transition_viewset_method(transition_name)
+            get_transition_viewset_method(transition_name, **kwargs)
         )
 
     return Mixin


### PR DESCRIPTION
This is handy when someone needs to set permission_classes or other options on
the detail_route decorator.
