### PR TITLE
Permissions and conditions check; configurable method kwargs

### DIFF
--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -20,8 +20,8 @@ def get_transition_viewset_method(transition_name, **kwargs):
         if not django_fsm.has_transition_perm(transition_method, request.user):
             raise PermissionDenied
 
-        if hasattr(object, 'get_{0}_kwargs'.format(transition_name)):
-            kwargs = getattr(object, 'get_{0}_kwargs'.format(transition_name))()
+        if hasattr(self, 'get_{0}_kwargs'.format(transition_name)):
+            kwargs = getattr(self, 'get_{0}_kwargs'.format(transition_name))()
         else:
             kwargs = {}
 

--- a/drf_fsm_transitions/viewset_mixins.py
+++ b/drf_fsm_transitions/viewset_mixins.py
@@ -1,5 +1,9 @@
+import inspect
+
+import django_fsm
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 
 def get_transition_viewset_method(transition_name, **kwargs):
@@ -11,7 +15,17 @@ def get_transition_viewset_method(transition_name, **kwargs):
         object = self.get_object()
         transition_method = getattr(object, transition_name)
 
-        transition_method(by=self.request.user)
+        if not django_fsm.can_proceed(transition_method):
+            raise ValidationError({'detail': 'Conditions not met'})
+        if not django_fsm.has_transition_perm(transition_method, request.user):
+            raise PermissionDenied
+
+        if hasattr(object, 'get_{0}_kwargs'.format(transition_name)):
+            kwargs = getattr(object, 'get_{0}_kwargs'.format(transition_name))()
+        else:
+            kwargs = {}
+
+        transition_method(**kwargs)
 
         if self.save_after_transition:
             object.save()


### PR DESCRIPTION
Check permissions and conditions before performing a state change, and
let an implementor calculate kwargs to be passed to the state change
method.

If you'd prefer these separately, then let me know. This is backwards incompatible as it removes the `by` parameter by default, so that might need fixing. It probably needs documentation, but at least it's a start.
